### PR TITLE
Add RegExp.compile tests

### DIFF
--- a/driver/v8/v8.mjsunit.status
+++ b/driver/v8/v8.mjsunit.status
@@ -979,7 +979,6 @@
   # builtins
   'html-string-funcs': [SKIP],
   'number-is': [SKIP],
-  'regexp-compile': [SKIP],
   'string-normalize': [SKIP],
   'asm/math-fround': [SKIP],
   'global-hash': [SKIP],
@@ -1140,7 +1139,7 @@
   # RegExp Issues
   'regexp-lastIndex': [SKIP],
   'string-slices-regexp': [SKIP],
-  'regress/regress-2058': [SKIP], 
+  'regress/regress-2058': [SKIP],
   'regress/regress-5566': [SKIP],
   'regress/regress-5836': [SKIP],
   'regress/regress-3229': [SKIP],


### PR DESCRIPTION
Since https://github.com/pando-project/escargot/pull/100 adds the RegExp.compile() function these tests can be enabled.

Signed-off-by: Daniel Balla <dballa@inf.u-szeged.hu>