### PR TITLE
Disable regress-329530.js due to the too deep recursion.

### DIFF
--- a/SpiderMonkey/js1_5/Regress/regress-329530.js
+++ b/SpiderMonkey/js1_5/Regress/regress-329530.js
@@ -1,4 +1,4 @@
-// |reftest| skip-if(Android)
+// |reftest| skip -- too deep recursion
 /* -*- Mode: C++; tab-width: 2; indent-tabs-mode: nil; c-basic-offset: 2 -*- */
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this


### PR DESCRIPTION
Signed-off-by: Robert Fancsik frobert@inf.u-szeged.hu