### PR TITLE
Disable  tests due to failing to ES6 Symbol.replace

### DIFF
--- a/SpiderMonkey/ecma_5/RegExp/regress-617935.js
+++ b/SpiderMonkey/ecma_5/RegExp/regress-617935.js
@@ -1,4 +1,4 @@
-// |reftest| skip-if(!xulRuntime.shell&&(Android||xulRuntime.OS=="WINNT")) silentfail
+// |reftest| skip -- slow
 /*
  * Any copyright is dedicated to the Public Domain.
  * http://creativecommons.org/licenses/publicdomain/
@@ -27,8 +27,8 @@ for (i = 0; i < 9; ++i) {
     bar += bar;
 }
 
-/* 
- * Resulting string should be 
+/*
+ * Resulting string should be
  * len(foo) * len(bar) = (2**10 * 32 + 1) * 8192 = 268443648
  * which will be larger than the max string length (2**28, or 268435456).
  */

--- a/driver/v8/v8.mjsunit.status
+++ b/driver/v8/v8.mjsunit.status
@@ -53,6 +53,10 @@
   # Issue 3784: setters-on-elements is flaky
   'setters-on-elements': [PASS, FAIL],
 
+  # This test-cases always fails in ES6 Well-known symbol replace
+  'regress/regress-2437': [SKIP],
+  'string-replace-gc': [SKIP],
+
   ##############################################################################
   # Too slow in debug mode with --stress-opt mode.
   'regress/regress-create-exception': [PASS, ['mode == debug', SKIP]],


### PR DESCRIPTION
Needed for pando-project/escargot#194

SpiderMonkey: regress-617935.js

This SpiderMonkey test will cause large memory allocation and it will timeout or fail.

V8: regress-2437.js

This test case only works in ES5.

V8: string-replace-gc

The reason is the same as the regress-617935.js test

Also ES6 regress-2437.js has been added

Signed-off-by: bence gabor kis <kisbg@inf.u-szeged.hu>