### PR TITLE
Disable spidermonkey test due to failing to ES6 Symbol.replace

### DIFF
--- a/SpiderMonkey/ecma_3/String/15.5.4.11.js
+++ b/SpiderMonkey/ecma_3/String/15.5.4.11.js
@@ -1,3 +1,4 @@
+// |reftest| skip
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */


### PR DESCRIPTION
    Disable tests due to failing to ES6 Symbol.replace

    SpiderMonkey/ecma_3/String/15.5.4.11.js:

    this test case only work in ES5 or below. Similar to V8 regress-2437.js

    Also modified 15.5.4.11.js has been added in escargot/es2015
