### PR TITLE
Add regexp-flags test and remove remove ES6 incompatible tests

### DIFF
--- a/driver/chakracore.x86.orig.txt
+++ b/driver/chakracore.x86.orig.txt
@@ -1054,7 +1054,7 @@ Running all tests
 [Operators] newBuiltin.js .......... Skip (Error message differ)
 [Operators] newProto.js .......... Pass
 [Operators] prototypeInheritance.js .......... Pass
-[Operators] prototypeInheritance2.js .......... Pass
+[Operators] prototypeInheritance2.js .......... Skip (Baseline not ES6 compatible)
 [Operators] zero.js .......... Pass
 [Conversions] toint32.js .......... Pass
 [Conversions] toint32_2.js .......... Skip (Implementation-dependent case)
@@ -1213,7 +1213,7 @@ Running all tests
 [strict] 12.delete.js .......... Pass
 [strict] 12.delete.js .......... Skip (-ForceStrictMode)
 [strict] 12.delete_sm.js .......... Pass
-[strict] 13.delete.js .......... Pass
+[strict] 13.delete.js .......... Skip (Baseline not ES6 compatible)
 [strict] 14.var.js .......... Pass
 [strict] 14.var.js .......... Skip (-ForceStrictMode)
 [strict] 14.var_sm.js .......... Pass
@@ -2053,13 +2053,13 @@ TESTNAME					TOTAL	PASS	FAIL	SKIP	PASS_RATIO
                Regex		32		19		0		13		(59%)
           Prototypes		8		7		0		1		(87%)
      GlobalFunctions		13		9		0		4		(69%)
-           Operators		32		25		0		7		(78%)
+           Operators		32		24		0		8		(75%)
          Conversions		5		3		0		2		(60%)
                  RWC		1		1		0		0		(100%)
                  Lib		16		3		0		13		(18%)
                 JSON		14		9		0		5		(64%)
                 Bugs		57		27		0		30		(47%)
-              strict		105		44		0		61		(41%)
+              strict		105		43		0		62		(40%)
                 utf8		3		3		0		0		(100%)
         UnifiedRegex		27		8		0		19		(29%)
           typedarray		47		16		0		31		(34%)
@@ -2074,4 +2074,4 @@ TESTNAME					TOTAL	PASS	FAIL	SKIP	PASS_RATIO
      switchStatement		28		24		0		4		(85%)
       DebuggerCommon		205		68		0		137		(33%)
 ==========================================================
-               Total		1998		1159		0		839		(58%)
+               Total		1998		1157		0		841		(57%)

--- a/driver/chakracore.x86_64.orig.txt
+++ b/driver/chakracore.x86_64.orig.txt
@@ -1054,7 +1054,7 @@ Running all tests
 [Operators] newBuiltin.js .......... Skip (Error message differ)
 [Operators] newProto.js .......... Pass
 [Operators] prototypeInheritance.js .......... Pass
-[Operators] prototypeInheritance2.js .......... Pass
+[Operators] prototypeInheritance2.js .......... Skip (Baseline not ES6 compatible)
 [Operators] zero.js .......... Pass
 [Conversions] toint32.js .......... Pass
 [Conversions] toint32_2.js .......... Skip (Implementation-dependent case)
@@ -1213,7 +1213,7 @@ Running all tests
 [strict] 12.delete.js .......... Pass
 [strict] 12.delete.js .......... Skip (-ForceStrictMode)
 [strict] 12.delete_sm.js .......... Pass
-[strict] 13.delete.js .......... Pass
+[strict] 13.delete.js .......... Skip (Baseline not ES6 compatible)
 [strict] 14.var.js .......... Pass
 [strict] 14.var.js .......... Skip (-ForceStrictMode)
 [strict] 14.var_sm.js .......... Pass
@@ -2053,13 +2053,13 @@ TESTNAME					TOTAL	PASS	FAIL	SKIP	PASS_RATIO
                Regex		32		19		0		13		(59%)
           Prototypes		8		7		0		1		(87%)
      GlobalFunctions		13		9		0		4		(69%)
-           Operators		32		25		0		7		(78%)
+           Operators		32		24		0		8		(75%)
          Conversions		5		3		0		2		(60%)
                  RWC		1		1		0		0		(100%)
                  Lib		16		3		0		13		(18%)
                 JSON		14		9		0		5		(64%)
                 Bugs		57		27		0		30		(47%)
-              strict		105		44		0		61		(41%)
+              strict		105		43		0		62		(40%)
                 utf8		3		3		0		0		(100%)
         UnifiedRegex		27		8		0		19		(29%)
           typedarray		47		16		0		31		(34%)
@@ -2074,4 +2074,4 @@ TESTNAME					TOTAL	PASS	FAIL	SKIP	PASS_RATIO
      switchStatement		28		24		0		4		(85%)
       DebuggerCommon		205		68		0		137		(33%)
 ==========================================================
-               Total		1998		1159		0		839		(58%)
+               Total		1998		1157		0		841		(57%)

--- a/driver/chakracore/Operators.rlexe.xml
+++ b/driver/chakracore/Operators.rlexe.xml
@@ -204,6 +204,7 @@
   </test>
   <test>
     <default>
+      <escargot-skip>Baseline not ES6 compatible</escargot-skip>
       <files>prototypeInheritance2.js</files>
       <baseline>prototypeInheritance2.baseline</baseline>
       <compile-flags>-ES6RegExPrototypeProperties-</compile-flags>

--- a/driver/chakracore/strict.rlexe.xml
+++ b/driver/chakracore/strict.rlexe.xml
@@ -464,6 +464,7 @@
   </test>
   <test>
     <default>
+      <escargot-skip>Baseline not ES6 compatible</escargot-skip>
       <files>13.delete.js</files>
       <baseline>13.delete.baseline</baseline>
       <compile-flags>-ES6RegExPrototypeProperties-</compile-flags>

--- a/driver/v8/v8.mjsunit.status
+++ b/driver/v8/v8.mjsunit.status
@@ -837,7 +837,6 @@
   'es6/reflect-prevent-extensions' : [SKIP],
   'es6/reflect-set-prototype-of' : [SKIP],
   'es6/regexp-constructor' : [SKIP],
-  'es6/regexp-flags' : [SKIP],
   'es6/regexp-sticky' : [SKIP],
   'es6/regexp-tolength' : [SKIP],
   'es6/regexp-tostring' : [SKIP],


### PR DESCRIPTION
This patch enables v8's regexp-flags.js test and makes the testrunner skip 13.delete.js and prototypeInheritance2.js tests in the ChakraCore testsuite.
The correct ES6 behaviour tests have been added in this [patch](https://github.com/pando-project/escargot/pull/271)

Signed-off-by: Daniel Balla <dballa@inf.u-szeged.hu>